### PR TITLE
chore: update protos Dockerfile to `alpine`

### DIFF
--- a/protos/Dockerfile
+++ b/protos/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 COPY ./*.proto /skyra/assets/protos/

--- a/protos/Dockerfile
+++ b/protos/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
+FROM alpine
 
 COPY ./*.proto /skyra/assets/protos/


### PR DESCRIPTION
This might explain why the image was big and using a lot of RAM.
